### PR TITLE
Add EverythingIsNonNull annotation, fix annotations.

### DIFF
--- a/src/main/java/com/uwetrottmann/thetvdb/TheTvdb.java
+++ b/src/main/java/com/uwetrottmann/thetvdb/TheTvdb.java
@@ -23,11 +23,11 @@ public class TheTvdb {
     public static final String HEADER_ACCEPT_LANGUAGE = "Accept-Language";
     public static final String HEADER_AUTHORIZATION = "Authorization";
 
-    private OkHttpClient okHttpClient;
-    private Retrofit retrofit;
+    @Nullable private OkHttpClient okHttpClient;
+    @Nullable private Retrofit retrofit;
 
     private String apiKey;
-    private String currentJsonWebToken;
+    @Nullable private String currentJsonWebToken;
 
     /**
      * Create a new manager instance.
@@ -36,12 +36,11 @@ public class TheTvdb {
         this.apiKey = apiKey;
     }
 
-    @Nullable
     public String apiKey() {
         return apiKey;
     }
 
-    public void apiKey(@Nullable String apiKey) {
+    public void apiKey(String apiKey) {
         this.apiKey = apiKey;
     }
 

--- a/src/main/java/com/uwetrottmann/thetvdb/TheTvdbAuthenticator.java
+++ b/src/main/java/com/uwetrottmann/thetvdb/TheTvdbAuthenticator.java
@@ -22,7 +22,8 @@ public class TheTvdbAuthenticator implements Authenticator {
     }
 
     @Override
-    public Request authenticate(Route route, Response response) throws IOException {
+    @Nullable
+    public Request authenticate(@Nullable Route route, Response response) throws IOException {
         return handleRequest(response, theTvdb);
     }
 
@@ -47,12 +48,12 @@ public class TheTvdbAuthenticator implements Authenticator {
         // get a new json web token with the API key
         Call<Token> loginCall = theTvdb.authentication().login(new LoginData(theTvdb.apiKey()));
         retrofit2.Response<Token> loginResponse = loginCall.execute();
-        if (!loginResponse.isSuccessful()) {
+        Token body = loginResponse.body();
+        if (!loginResponse.isSuccessful() || body == null) {
             return null; // failed to retrieve a token, give up.
         }
 
-        //noinspection ConstantConditions // successful response body is never null
-        String jsonWebToken = loginResponse.body().token;
+        String jsonWebToken = body.token;
         theTvdb.jsonWebToken(jsonWebToken);
 
         // retry request

--- a/src/main/java/com/uwetrottmann/thetvdb/internal/EverythingIsNonNull.java
+++ b/src/main/java/com/uwetrottmann/thetvdb/internal/EverythingIsNonNull.java
@@ -1,0 +1,24 @@
+package com.uwetrottmann.thetvdb.internal;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierDefault;
+
+/**
+ * Extends {@code ParametersAreNonnullByDefault} to also apply to method results and fields.
+ *
+ * @see javax.annotation.ParametersAreNonnullByDefault
+ */
+@Documented
+@Nonnull
+@TypeQualifierDefault({
+        ElementType.FIELD,
+        ElementType.METHOD,
+        ElementType.PARAMETER
+})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EverythingIsNonNull {
+}

--- a/src/main/java/com/uwetrottmann/thetvdb/package-info.java
+++ b/src/main/java/com/uwetrottmann/thetvdb/package-info.java
@@ -1,4 +1,5 @@
-@ParametersAreNonnullByDefault
+/**
+ * A Java wrapper around the TheTVDB API using retrofit 2.
+ */
+@com.uwetrottmann.thetvdb.internal.EverythingIsNonNull
 package com.uwetrottmann.thetvdb;
-
-import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/java/com/uwetrottmann/thetvdb/BaseTestCase.java
+++ b/src/test/java/com/uwetrottmann/thetvdb/BaseTestCase.java
@@ -39,6 +39,7 @@ public abstract class BaseTestCase {
 
     @BeforeClass
     public static void setUpOnce() {
+        //noinspection ConstantConditions
         if (API_KEY.length() == 0) {
             throw new IllegalArgumentException("Set a valid value for API_KEY.");
         }
@@ -48,19 +49,31 @@ public abstract class BaseTestCase {
         return theTvdb;
     }
 
+    /**
+     * Execute call with non-Void response body.
+     */
     protected <T> T executeCall(Call<T> call) throws IOException {
         Response<T> response = call.execute();
-        if (response.isSuccessful()) {
-            T body = response.body();
-            if (body == null) {
-                fail("body == null");
-            } else {
-                return body;
-            }
-        } else {
+        if (!response.isSuccessful()) {
             handleFailedResponse(response);
         }
-        return null;
+        T body = response.body();
+        if (body != null) {
+            return body;
+        } else {
+            throw new IllegalStateException("Body should not be null for successful response");
+        }
+    }
+
+    /**
+     * Execute call with Void response body.
+     */
+    protected <T> Response<T> executeVoidCall(Call<T> call) throws IOException {
+        Response<T> response = call.execute();
+        if (!response.isSuccessful()) {
+            handleFailedResponse(response); // will throw error
+        }
+        return response;
     }
 
     private static void handleFailedResponse(Response response) {

--- a/src/test/java/com/uwetrottmann/thetvdb/services/TheTvdbSeriesTest.java
+++ b/src/test/java/com/uwetrottmann/thetvdb/services/TheTvdbSeriesTest.java
@@ -36,7 +36,7 @@ public class TheTvdbSeriesTest extends BaseTestCase {
     @Test
     public void test_seriesHeader() throws IOException {
         Call<Void> call = getTheTvdb().series().seriesHeader(TestData.SERIES_TVDB_ID, TestData.LANGUAGE_EN);
-        Headers headers = call.execute().headers();
+        Headers headers = executeVoidCall(call).headers();
         assertThat(headers.get("Last-Modified")).isNotEmpty();
     }
 


### PR DESCRIPTION
- Can no longer set null API key.
- Authenticator fails if token body is null (though should never happen
  if response was successful).