### PR TITLE
Support TheTVDB.com API 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The TVDB API wrapper in Java written using retrofit.
 
-Currently supported [The TVDB API](https://api.thetvdb.com/swagger) version: [`2.2.0`](https://gitlab.thetvdb.com/site/thetvdb_api/issues)
+Tested to work with [The TVDB API](https://api.thetvdb.com/swagger) version: [`3.0.0`](https://gitlab.thetvdb.com/site/thetvdb_api/issues)
 
 [Supported endpoints](https://github.com/UweTrottmann/thetvdb-java/issues/1)
 

--- a/src/main/java/com/uwetrottmann/thetvdb/TheTvdb.java
+++ b/src/main/java/com/uwetrottmann/thetvdb/TheTvdb.java
@@ -17,9 +17,7 @@ public class TheTvdb {
 
     public static final String API_HOST = "api.thetvdb.com";
     public static final String API_URL = "https://" + API_HOST + "/";
-    public static final String API_VERSION = "2.2.0";
 
-    public static final String HEADER_ACCEPT = "Accept";
     public static final String HEADER_ACCEPT_LANGUAGE = "Accept-Language";
     public static final String HEADER_AUTHORIZATION = "Authorization";
 

--- a/src/main/java/com/uwetrottmann/thetvdb/TheTvdbInterceptor.java
+++ b/src/main/java/com/uwetrottmann/thetvdb/TheTvdbInterceptor.java
@@ -21,8 +21,8 @@ public class TheTvdbInterceptor implements Interceptor {
     }
 
     /**
-     * If the host matches {@link TheTvdb#API_HOST} adds an Accept header for the current {@link TheTvdb#API_VERSION}
-     * and if not present an Authorization header using the given JSON web token.
+     * If the host matches {@link TheTvdb#API_HOST} if not present adds an Authorization header
+     * using the given JSON web token.
      */
     public static Response handleIntercept(Chain chain, @Nullable String jsonWebToken) throws IOException {
         Request request = chain.request();
@@ -33,9 +33,6 @@ public class TheTvdbInterceptor implements Interceptor {
         }
 
         Request.Builder builder = request.newBuilder();
-
-        // request specific API version
-        builder.header(TheTvdb.HEADER_ACCEPT, "application/vnd.thetvdb.v" + TheTvdb.API_VERSION);
 
         // add authorization header
         if (hasNoAuthorizationHeader(request) && jsonWebTokenIsNotEmpty(jsonWebToken)) {

--- a/src/test/java/com/uwetrottmann/thetvdb/services/TheTvdbEpisodesTest.java
+++ b/src/test/java/com/uwetrottmann/thetvdb/services/TheTvdbEpisodesTest.java
@@ -14,14 +14,22 @@ public class TheTvdbEpisodesTest extends BaseTestCase {
         EpisodeResponse episodeResponse = executeCall(
                 getTheTvdb().episodes().get(TestData.EPISODE_TVDB_ID, TestData.LANGUAGE_EN));
         Episode episode = episodeResponse.data;
+        assertThat(episode).isNotNull();
         TestData.assertBasicEpisode(episode);
         assertThat(episode.id).isEqualTo(TestData.EPISODE_TVDB_ID);
     }
 
     @Test
     public void test_getInvalidLanguage() throws Exception {
+        // Since API 3.0.0 this returns English instead of an error.
+        // Reported to forums: https://forums.thetvdb.com/viewtopic.php?p=161690#p161690
+        // Unsure if this is a regression or intended.
         EpisodeResponse episodeResponse = executeCall(getTheTvdb().episodes().get(TestData.EPISODE_TVDB_ID, "xx"));
-        assertThat(episodeResponse.errors.invalidLanguage).isNotEmpty();
+//        assertThat(episodeResponse.errors.invalidLanguage).isNotEmpty();
+        Episode episode = episodeResponse.data;
+        assertThat(episode).isNotNull();
+        TestData.assertBasicEpisode(episode);
+        assertThat(episode.id).isEqualTo(TestData.EPISODE_TVDB_ID);
     }
 
 }

--- a/src/test/java/com/uwetrottmann/thetvdb/services/TheTvdbSeriesTest.java
+++ b/src/test/java/com/uwetrottmann/thetvdb/services/TheTvdbSeriesTest.java
@@ -54,15 +54,25 @@ public class TheTvdbSeriesTest extends BaseTestCase {
     @Test
     public void test_episodes() throws IOException {
         Integer page = 0;
+        int episodeCount = 0;
+        int pageCount = 0;
         while (page != null) {
             Call<EpisodesResponse> call = getTheTvdb().series().episodes(TestData.SERIES_TVDB_ID_STARGATE, page,
                     TestData.LANGUAGE_EN);
             EpisodesResponse response = executeCall(call);
 
+            assertThat(response.data).isNotNull();
             assertEpisodes(response.data);
+            episodeCount += response.data.size();
 
+            pageCount++;
+            assertThat(response.links).isNotNull();
             page = response.links.next;
         }
+        // Assert this to be aware of API failures.
+        assertThat(episodeCount).isEqualTo(222);
+        // Assert this to be aware of page size changes.
+        assertThat(pageCount).isEqualTo(3);
     }
 
     @Test


### PR DESCRIPTION
- Drop requesting API version, has never worked.
- Note regression when requesting episode info with invalid language.
- [x] Querying episodes by DVD season returns HTTP 500.
- [x] Getting episodes only returns 1 page of 100 episodes.