### PR TITLE
Process image element in thetvdb tv show search answer.

### DIFF
--- a/src/main/java/com/uwetrottmann/thetvdb/entities/Series.java
+++ b/src/main/java/com/uwetrottmann/thetvdb/entities/Series.java
@@ -20,6 +20,7 @@ public class Series {
     public String slug;
 
     public String poster;
+    public String image;
     /** Image path suffix, like "graphical/83462-g20.jpg". */
     public String banner;
     public String fanart;


### PR DESCRIPTION
Since recently thetvdb puts the banner url in the image element and set banner to null.

See https://github.com/nova-video-player/aos-AVP/issues/289

See https://github.com/UweTrottmann/thetvdb-java/issues/28